### PR TITLE
[FIX] purchase_operating_unit, double check if picking_id = None

### DIFF
--- a/purchase_operating_unit/models/purchase.py
+++ b/purchase_operating_unit/models/purchase.py
@@ -85,8 +85,9 @@ class PurchaseOrder(models.Model):
     def action_picking_create(self):
         picking_obj = self.env['stock.picking']
         picking_id = super(PurchaseOrder, self).action_picking_create()
-        picking = picking_obj.browse(picking_id)
-        picking.operating_unit_id = self.operating_unit_id.id
+        if picking_id:
+            picking = picking_obj.browse(picking_id)
+            picking.operating_unit_id = self.operating_unit_id.id
         return picking_id
 
     @api.model


### PR DESCRIPTION
We found error in some case, this method is called > 1 time, and the first time picking_id does not exist yet.
This fix shouldn't change anything, just prevent.
