### PR TITLE
Review round

### DIFF
--- a/purchase_operating_unit/__openerp__.py
+++ b/purchase_operating_unit/__openerp__.py
@@ -6,8 +6,8 @@
 
 {
     "name": "Operating Unit in Purchase Orders",
-    "summary": "An operating unit (OU) is an organizational entity part of a\
-        company",
+    "summary": "An operating unit (OU) is an organizational entity part of a "
+               "company",
     "version": "9.0.1.0.0",
     "author": "Eficent Business and IT Consulting Services S.L., "
               "Serpent Consulting Services Pvt. Ltd.,"

--- a/purchase_operating_unit/demo/purchase_order_demo.xml
+++ b/purchase_operating_unit/demo/purchase_order_demo.xml
@@ -1,34 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-    <data>
+<odoo>
 
-        <record id="purchase.purchase_order_1" model="purchase.order">
-            <field name="operating_unit_id" ref="operating_unit.main_operating_unit"/>
-        </record>
+    <record id="purchase.purchase_order_1" model="purchase.order">
+        <field name="operating_unit_id" ref="operating_unit.main_operating_unit"/>
+    </record>
 
-        <record id="purchase.purchase_order_2" model="purchase.order">
-            <field name="operating_unit_id" ref="operating_unit.main_operating_unit"/>
-        </record>
+    <record id="purchase.purchase_order_2" model="purchase.order">
+        <field name="operating_unit_id" ref="operating_unit.main_operating_unit"/>
+    </record>
 
-        <record id="purchase.purchase_order_3" model="purchase.order">
-            <field name="operating_unit_id" ref="operating_unit.main_operating_unit"/>
-        </record>
+    <record id="purchase.purchase_order_3" model="purchase.order">
+        <field name="operating_unit_id" ref="operating_unit.main_operating_unit"/>
+    </record>
 
-        <record id="purchase.purchase_order_4" model="purchase.order">
-            <field name="operating_unit_id" ref="operating_unit.main_operating_unit"/>
-        </record>
+    <record id="purchase.purchase_order_4" model="purchase.order">
+        <field name="operating_unit_id" ref="operating_unit.main_operating_unit"/>
+    </record>
 
-        <record id="purchase.purchase_order_5" model="purchase.order">
-            <field name="operating_unit_id" ref="operating_unit.main_operating_unit"/>
-        </record>
+    <record id="purchase.purchase_order_5" model="purchase.order">
+        <field name="operating_unit_id" ref="operating_unit.main_operating_unit"/>
+    </record>
 
-        <record id="purchase.purchase_order_6" model="purchase.order">
-            <field name="operating_unit_id" ref="operating_unit.main_operating_unit"/>
-        </record>
+    <record id="purchase.purchase_order_6" model="purchase.order">
+        <field name="operating_unit_id" ref="operating_unit.main_operating_unit"/>
+    </record>
 
-        <record id="purchase.purchase_order_7" model="purchase.order">
-            <field name="operating_unit_id" ref="operating_unit.main_operating_unit"/>
-        </record>
+    <record id="purchase.purchase_order_7" model="purchase.order">
+        <field name="operating_unit_id" ref="operating_unit.main_operating_unit"/>
+    </record>
 
-    </data>
-</openerp>
+</odoo>

--- a/purchase_operating_unit/models/procurement.py
+++ b/purchase_operating_unit/models/procurement.py
@@ -3,9 +3,8 @@
 # - Jordi Ballester Alomar
 # © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
-from openerp import api, models
-from openerp.tools.translate import _
-from openerp.exceptions import UserError
+from openerp import _, api, models
+from openerp.exceptions import ValidationError
 
 
 class ProcurementOrder(models.Model):
@@ -15,12 +14,14 @@ class ProcurementOrder(models.Model):
     @api.constrains('purchase_line_id')
     def _check_purchase_order_operating_unit(self):
         purchase = self.purchase_line_id.order_id
-        if purchase and \
-                purchase.operating_unit_id !=\
-                self.location_id.operating_unit_id:
-            raise UserError(_('Configuration error!\nThe Quotation / Purchase\
-            Order and the Procurement Order must belong to the\
-            same Operating Unit.'))
+        location = self.location_id
+        if (purchase and
+                purchase.operating_unit_id != location.operating_unit_id):
+            raise ValidationError(
+                _('Configuration error\nThe Quotation / Purchase Order and '
+                  'the Procurement Order must belong to the same '
+                  'Operating Unit.')
+                )
 
     @api.multi
     def _prepare_purchase_order(self, partner):

--- a/purchase_operating_unit/models/purchase.py
+++ b/purchase_operating_unit/models/purchase.py
@@ -3,8 +3,8 @@
 # - Jordi Ballester Alomar
 # © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
-from openerp import _, api, exceptions, fields, models
-from openerp.exceptions import Warning
+from openerp import _, api, fields, models
+from openerp.exceptions import ValidationError, UserError
 
 
 class PurchaseOrder(models.Model):
@@ -23,48 +23,57 @@ class PurchaseOrder(models.Model):
             res = types[:1].id
         return res
 
-    operating_unit_id = fields.Many2one('operating.unit', 'Operating Unit',
-                                        default=lambda self:
-                                        self.env['res.users'].
-                                        operating_unit_default_get(self._uid))
-    requesting_operating_unit_id =\
-        fields.Many2one('operating.unit', 'Requesting Operating Unit',
-                        default=lambda self:
-                        self.env['res.users'].
-                        operating_unit_default_get(self._uid))
+    operating_unit_id = fields.Many2one(
+        comodel_name='operating.unit',
+        string='Operating Unit',
+        default=lambda self: (self.env['res.users'].
+                              operating_unit_default_get(self.env.uid))
+    )
+    requesting_operating_unit_id = fields.Many2one(
+        comodel_name='operating.unit',
+        string='Requesting Operating Unit',
+        default=lambda self: (self.env['res.users'].
+                              operating_unit_default_get(self.env.uid))
+    )
 
-    picking_type_id = fields.Many2one('stock.picking.type', 'Deliver To',
-                                      help="This will determine picking type "
-                                           "of incoming shipment",
-                                      required=True,
-                                      states={'confirmed':
-                                              [('readonly', True)],
-                                              'approved': [('readonly', True)],
-                                              'done': [('readonly', True)]},
-                                      default=_default_picking_type)
+    picking_type_id = fields.Many2one(
+        comodel_name='stock.picking.type',
+        string='Deliver To',
+        help="This will determine picking type of incoming shipment",
+        required=True,
+        states={'confirmed': [('readonly', True)],
+                'approved': [('readonly', True)],
+                'done': [('readonly', True)]},
+        default=lambda self: self._default_picking_type(),
+    )
 
-    @api.one
     @api.constrains('operating_unit_id', 'picking_type_id')
     def _check_warehouse_operating_unit(self):
-        picking_type = self.picking_type_id
-        if picking_type:
-            if picking_type.warehouse_id and\
-                    picking_type.warehouse_id.operating_unit_id\
-                    and self.operating_unit_id and\
-                    picking_type.warehouse_id.operating_unit_id !=\
-                    self.operating_unit_id:
-                raise Warning(_('Configuration error!\nThe\
-                Quotation / Purchase Order and the Warehouse of picking type\
-                must belong to the same Operating Unit.'))
+        for record in self:
+            picking_type = record.picking_type_id
+            if not record.picking_type_id:
+                continue
+            warehouse = picking_type.warehouse_id
+            if (picking_type.warehouse_id and
+                    picking_type.warehouse_id.operating_unit_id and
+                    record.operating_unit_id and
+                    warehouse.operating_unit_id != record.operating_unit_id):
+                raise ValidationError(
+                    _('Configuration error\nThe Quotation / Purchase Order '
+                      'and the Warehouse of picking type must belong to the '
+                      'same Operating Unit.')
+                )
 
-    @api.one
     @api.constrains('operating_unit_id', 'requesting_operating_unit_id',
                     'company_id')
     def _check_company_operating_unit(self):
-        if self.company_id and self.operating_unit_id and\
-                self.company_id != self.operating_unit_id.company_id:
-            raise Warning(_('Configuration error!\nThe Company in the\
-            Purchase Order and in the Operating Unit must be the same.'))
+        for record in self:
+            if (record.company_id and record.operating_unit_id and
+                    record.company_id != record.operating_unit_id.company_id):
+                raise ValidationError(
+                    _('Configuration error\nThe Company in the Purchase Order '
+                      'and in the Operating Unit must be the same.')
+                )
 
     @api.onchange('operating_unit_id')
     def _onchange_operating_unit_id(self):
@@ -76,43 +85,42 @@ class PurchaseOrder(models.Model):
             if types:
                 self.picking_type_id = types[:1]
             else:
-                raise exceptions.Warning(_("No Warehouse found with the "
-                                           "Operating Unit indicated in the "
-                                           "Purchase Order!"))
+                raise UserError(
+                    _("No Warehouse found with the Operating Unit indicated "
+                      "in the Purchase Order")
+                )
 
     @api.model
     def _prepare_picking(self):
         picking_vals = super(PurchaseOrder, self)._prepare_picking()
-        picking_vals['operating_unit_id'] = self.operating_unit_id and\
-            self.operating_unit_id.id
+        picking_vals['operating_unit_id'] = self.operating_unit_id.id
         return picking_vals
 
-    @api.one
     @api.constrains('invoice_ids')
     def _check_invoice_ou(self):
         for po in self:
             for invoice in po.invoice_ids:
                 if invoice.operating_unit_id != po.operating_unit_id:
-                    raise Warning(_('The operating unit of the purchase order '
-                                    'must be the same as in the '
-                                    'associated invoices.'))
+                    raise ValidationError(
+                        _('The operating unit of the purchase order must '
+                          'be the same as in the associated invoices.')
+                    )
 
 
 class PurchaseOrderLine(models.Model):
     _inherit = 'purchase.order.line'
 
-    operating_unit_id = fields.Many2one('operating.unit',
-                                        related='order_id.operating_unit_id',
+    operating_unit_id = fields.Many2one(related='order_id.operating_unit_id',
                                         string='Operating Unit', readonly=True)
 
-    @api.one
     @api.constrains('invoice_lines')
     def _check_invoice_ou(self):
         for line in self:
             for inv_line in line.invoice_lines:
-                if inv_line.invoice_id and \
-                    inv_line.invoice_id.operating_unit_id != \
-                        line.operating_unit_id:
-                    raise Warning(_('The operating unit of the purchase order '
-                                    'must be the same as in the '
-                                    'associated invoices.'))
+                invoice_operating_unit = inv_line.invoice_id.operating_unit_id
+                if (inv_line.invoice_id and
+                        invoice_operating_unit != line.operating_unit_id):
+                    raise ValidationError(
+                        _('The operating unit of the purchase order must '
+                          'be the same as in the associated invoices.')
+                    )

--- a/purchase_operating_unit/security/purchase_security.xml
+++ b/purchase_operating_unit/security/purchase_security.xml
@@ -1,28 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-    <data noupdate="1">
+<odoo noupdate="1">
 
-        <record id="ir_rule_purchase_order_allowed_operating_units" model="ir.rule">
-            <field name="model_id" ref="purchase.model_purchase_order"/>
-            <field name="domain_force">['|',('operating_unit_id','=',False),('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
-            <field name="name">PO's from allowed operating units</field>
-            <field name="global" eval="True"/>
-            <field eval="0" name="perm_unlink"/>
-            <field eval="0" name="perm_write"/>
-            <field eval="1" name="perm_read"/>
-            <field eval="0" name="perm_create"/>
-        </record>
+    <record id="ir_rule_purchase_order_allowed_operating_units" model="ir.rule">
+        <field name="model_id" ref="purchase.model_purchase_order"/>
+        <field name="domain_force">['|',('operating_unit_id','=',False),('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
+        <field name="name">PO's from allowed operating units</field>
+        <field name="global" eval="True"/>
+        <field eval="0" name="perm_unlink"/>
+        <field eval="0" name="perm_write"/>
+        <field eval="1" name="perm_read"/>
+        <field eval="0" name="perm_create"/>
+    </record>
 
-        <record id="ir_rule_purchase_order_line_allowed_operating_units" model="ir.rule">
-            <field name="model_id" ref="purchase.model_purchase_order_line"/>
-            <field name="domain_force">['|',('operating_unit_id','=',False),('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
-            <field name="name">PO lines from allowed operating units</field>
-            <field name="global" eval="True"/>
-            <field eval="0" name="perm_unlink"/>
-            <field eval="0" name="perm_write"/>
-            <field eval="1" name="perm_read"/>
-            <field eval="0" name="perm_create"/>
-        </record>
+    <record id="ir_rule_purchase_order_line_allowed_operating_units" model="ir.rule">
+        <field name="model_id" ref="purchase.model_purchase_order_line"/>
+        <field name="domain_force">['|',('operating_unit_id','=',False),('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
+        <field name="name">PO lines from allowed operating units</field>
+        <field name="global" eval="True"/>
+        <field eval="0" name="perm_unlink"/>
+        <field eval="0" name="perm_write"/>
+        <field eval="1" name="perm_read"/>
+        <field eval="0" name="perm_create"/>
+    </record>
 
-    </data>
-</openerp>
+</odoo>

--- a/purchase_operating_unit/views/purchase_order_line_view.xml
+++ b/purchase_operating_unit/views/purchase_order_line_view.xml
@@ -1,43 +1,41 @@
 <?xml version="1.0"?>
-<openerp>
-    <data>
+<odoo>
 
-        <record id="purchase_order_line_tree" model="ir.ui.view">
-            <field name="name">purchase_order_line_tree</field>
-            <field name="model">purchase.order.line</field>
-            <field name="inherit_id" ref="purchase.purchase_order_line_tree" />
-            <field name="arch" type="xml">
-                <field name="partner_id" position="after">
-                    <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
-                </field>
+    <record id="purchase_order_line_tree" model="ir.ui.view">
+        <field name="name">purchase_order_line_tree</field>
+        <field name="model">purchase.order.line</field>
+        <field name="inherit_id" ref="purchase.purchase_order_line_tree" />
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
             </field>
-        </record>
+        </field>
+    </record>
 
-        <record id="purchase_order_line_form" model="ir.ui.view">
-            <field name="name">purchase_order_line_form</field>
-            <field name="model">purchase.order.line</field>
-            <field name="inherit_id" ref="purchase.purchase_order_line_form2" />
-            <field name="arch" type="xml">
-                <field name="price_unit" position="after">
-                    <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
-                </field>
+    <record id="purchase_order_line_form" model="ir.ui.view">
+        <field name="name">purchase_order_line_form</field>
+        <field name="model">purchase.order.line</field>
+        <field name="inherit_id" ref="purchase.purchase_order_line_form2" />
+        <field name="arch" type="xml">
+            <field name="price_unit" position="after">
+                <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
             </field>
-        </record>
+        </field>
+    </record>
 
-        <record id="purchase_order_line_search" model="ir.ui.view">
-            <field name="name">purchase_order_line_search</field>
-            <field name="model">purchase.order.line</field>
-            <field name="inherit_id" ref="purchase.purchase_order_line_search" />
-            <field name="arch" type="xml">
-                <xpath expr="//filter[@name='groupby_supplier']" position="after">
-                    <filter string="Operating Unit" groups="operating_unit.group_multi_operating_unit"
-                          context="{'group_by':'operating_unit_id'}"/>
-                </xpath>
-                <field name="partner_id" position="after">
-                    <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
-                </field>
+    <record id="purchase_order_line_search" model="ir.ui.view">
+        <field name="name">purchase_order_line_search</field>
+        <field name="model">purchase.order.line</field>
+        <field name="inherit_id" ref="purchase.purchase_order_line_search" />
+        <field name="arch" type="xml">
+            <xpath expr="//filter[@name='groupby_supplier']" position="after">
+                <filter string="Operating Unit" groups="operating_unit.group_multi_operating_unit"
+                      context="{'group_by':'operating_unit_id'}"/>
+            </xpath>
+            <field name="partner_id" position="after">
+                <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
             </field>
-        </record>
+        </field>
+    </record>
 
-    </data>
-</openerp>
+</odoo>

--- a/purchase_operating_unit/views/purchase_order_view.xml
+++ b/purchase_operating_unit/views/purchase_order_view.xml
@@ -1,52 +1,50 @@
 <?xml version="1.0"?>
-<openerp>
-    <data>
+<odoo>
 
-        <record id="purchase_order_tree" model="ir.ui.view">
-            <field name="name">purchase_order_tree</field>
-            <field name="model">purchase.order</field>
-            <field name="inherit_id" ref="purchase.purchase_order_tree" />
-            <field name="arch" type="xml">
-                <field name="origin" position="after">
-                    <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
-                </field>
+    <record id="purchase_order_tree" model="ir.ui.view">
+        <field name="name">purchase_order_tree</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_tree" />
+        <field name="arch" type="xml">
+            <field name="origin" position="after">
+                <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
             </field>
-        </record>
+        </field>
+    </record>
 
-        <record id="purchase_order_form" model="ir.ui.view">
-            <field name="name">purchase_order_form</field>
-            <field name="model">purchase.order</field>
-            <field name="inherit_id" ref="purchase.purchase_order_form" />
-            <field name="arch" type="xml">
-                <field name="partner_ref" position="after">
-                    <field name="requesting_operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
+    <record id="purchase_order_form" model="ir.ui.view">
+        <field name="name">purchase_order_form</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form" />
+        <field name="arch" type="xml">
+            <field name="partner_ref" position="after">
+                <field name="requesting_operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
 <!--                          on_change="onchange_operating_unit_id(requesting_operating_unit_id,operating_unit_id)"/> -->
-                    <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
+                <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
 <!--                          on_change="onchange_operating_unit_id(requesting_operating_unit_id,operating_unit_id)"/> -->
-                </field>
-                <xpath expr="//field[@name='order_line']"
-                     position="attributes">
-                    <attribute name="context">{'operating_unit_id': operating_unit_id}</attribute>
-                </xpath>
+            </field>
+            <xpath expr="//field[@name='order_line']"
+                 position="attributes">
+                <attribute name="context">{'operating_unit_id': operating_unit_id}</attribute>
+            </xpath>
 <!--                 <field name="warehouse_id" position="attributes"> -->
 <!--                     <attribute name="on_change">onchange_warehouse_id(warehouse_id,requesting_operating_unit_id,operating_unit_id)</attribute> -->
 <!--                 </field> -->
-            </field>
-        </record>
+        </field>
+    </record>
 
-        <record id="view_purchase_order_filter" model="ir.ui.view">
-            <field name="name">view_purchase_order_filter</field>
-            <field name="model">purchase.order</field>
-            <field name="inherit_id" ref="purchase.view_purchase_order_filter" />
-            <field name="arch" type="xml">
-                <xpath expr="//group[@expand='0']" position="after">
-                    <filter string="Operating Unit" context="{'group_by':'operating_unit_id'}" groups="operating_unit.group_multi_operating_unit"/>
-                </xpath>
-                <field name="partner_id" position="after">
-                    <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
-                </field>
+    <record id="view_purchase_order_filter" model="ir.ui.view">
+        <field name="name">view_purchase_order_filter</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.view_purchase_order_filter" />
+        <field name="arch" type="xml">
+            <xpath expr="//group[@expand='0']" position="after">
+                <filter string="Operating Unit" context="{'group_by':'operating_unit_id'}" groups="operating_unit.group_multi_operating_unit"/>
+            </xpath>
+            <field name="partner_id" position="after">
+                <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
             </field>
-        </record>
+        </field>
+    </record>
 
-    </data>
 </openerp>


### PR DESCRIPTION
* Replace \ in strings by string concatenation to prevent inserting
  spaces in texts
* Replace \ where possible by usage of parenthesis
* Replace <openerp><data> by <odoo> xml element
* Use self.env.uid rather than self._env (private attribute)
* Use proper ValidationError/UserError rather than Warning (collides
  with builtins)
* Remove @api.one (deprecated)
* Always use a lambda for default values so we can properly override the
  field
* Remove exclamation point in error messages